### PR TITLE
Avoid overriding style if there are no ANSI codes

### DIFF
--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
@@ -152,11 +152,13 @@ public class AnsiConsoleStyleListener implements LineStyleListener {
 
             addRange(ranges, event.lineOffset + start, end - start, defStyle.foreground, true);
         }
-        if (lastRangeEnd != currentText.length())
-            addRange(ranges, event.lineOffset + lastRangeEnd, currentText.length() - lastRangeEnd, defStyle.foreground, false);
-        lastAttributes = currentAttributes.clone();
 
-        if (!ranges.isEmpty())
+        if (!ranges.isEmpty()) {
+            if (lastRangeEnd != currentText.length()) {
+                addRange(ranges, event.lineOffset + lastRangeEnd, currentText.length() - lastRangeEnd, defStyle.foreground, false);
+            }
+            lastAttributes = currentAttributes.clone();
             event.styles = ranges.toArray(new StyleRange[ranges.size()]);
+        }
     }
 }


### PR DESCRIPTION
This resolves an issue wherein no ranges were identified but the `if (lastRangeEnd != currentText.length())` block was still executed, overriding the style of the line.
