### PR TITLE
Do not impose a foreground color for non-ANSI parts

### DIFF
--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
@@ -156,13 +156,13 @@ public class AnsiConsoleStyleListener implements LineStyleListener {
             }
 
             if (lastRangeEnd != start)
-                addRange(ranges, event.lineOffset + lastRangeEnd, start - lastRangeEnd, defStyle.foreground, false);
+                addRange(ranges, event.lineOffset + lastRangeEnd, start - lastRangeEnd, null, false);
             lastAttributes = currentAttributes.clone();
 
             addRange(ranges, event.lineOffset + start, end - start, defStyle.foreground, true);
         }
         if (lastRangeEnd != currentText.length())
-            addRange(ranges, event.lineOffset + lastRangeEnd, currentText.length() - lastRangeEnd, defStyle.foreground, false);
+            addRange(ranges, event.lineOffset + lastRangeEnd, currentText.length() - lastRangeEnd, null, false);
         lastAttributes = currentAttributes.clone();
 
         if (!ranges.isEmpty())


### PR DESCRIPTION
Fixes #15

Counterclockwise reuses the AnsiConsole LineStyleListener in its REPL View.
What we'd like is for the LineStyleListener to only place colors on escaped chars, and let the default styles managed by the StyledText "as-is".

Currently, the imposed foreground color (black) does not work when the user switches to a Dark Theme (with a dark background).