### PR TITLE
changed the default behavior of the copy action to remove escapes

### DIFF
--- a/AnsiConsole/plugin.xml
+++ b/AnsiConsole/plugin.xml
@@ -38,7 +38,7 @@
 			class="mnita.ansiconsole.actions.AnsiConsoleCopyIconAction"
 			icon="icons/ansiconsolecopy.gif"
 			id="mnita.ansiconsole.AnsiConsoleCopyIconAction"
-			label="Copy plain text"
+			label="Copy raw text (including escape sequences)"
 			style="push"
 			toolbarPath="additions">
 		</action>

--- a/AnsiConsole/src/mnita/ansiconsole/actions/AnsiConsoleCopyIconAction.java
+++ b/AnsiConsole/src/mnita/ansiconsole/actions/AnsiConsoleCopyIconAction.java
@@ -1,45 +1,28 @@
 package mnita.ansiconsole.actions;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.ClipboardOwner;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IViewActionDelegate;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.part.PageBookView;
 
-import mnita.ansiconsole.AnsiConsoleUtils;
+import mnita.ansiconsole.utils.AnsiConsoleCopyToClipboardUtil;
 
-public class AnsiConsoleCopyIconAction implements IViewActionDelegate, ClipboardOwner {
-    PageBookView consoleView = null;
+public class AnsiConsoleCopyIconAction implements IViewActionDelegate {
+	
+    private PageBookView consoleView = null;
+    private AnsiConsoleCopyToClipboardUtil clipboardUtil = new AnsiConsoleCopyToClipboardUtil();
 
+   
     @Override
     public void run(IAction action) {
-        String text = "";
-
         IPage currentPage = (consoleView == null) ? null : consoleView.getCurrentPage();
         if (currentPage != null) {
             Control control = currentPage.getControl();
-            if (control instanceof StyledText) {
-                StyledText styledText = (StyledText) control;
-                text = styledText.getSelectionText();
-                if (text.isEmpty()) {
-                    text = styledText.getText();
-                }
-                text = text.replaceAll(AnsiConsoleUtils.ESCAPE_SEQUENCE_REGEX, "");        
-            }
+            clipboardUtil.copyRawToClipboard(control);
         }
-
-        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        StringSelection stringSelection = new StringSelection(text);
-        clipboard.setContents(stringSelection, new AnsiConsoleCopyIconAction());
     }
 
     @Override
@@ -52,11 +35,7 @@ public class AnsiConsoleCopyIconAction implements IViewActionDelegate, Clipboard
 
     @Override
     public void selectionChanged(IAction action, ISelection selection) {
-        // Nothing to do, but we are forced to implement it for ClipboardOwner
+        // Nothing to do, but we are forced to implement it for IViewActionDelegate
     }
 
-    @Override
-    public void lostOwnership(Clipboard clipboard, Transferable transferable) {
-        // Nothing to do, but we are forced to implement it for ClipboardOwner
-    }
 }

--- a/AnsiConsole/src/mnita/ansiconsole/actions/AnsiConsoleCopyToClipboardAction.java
+++ b/AnsiConsole/src/mnita/ansiconsole/actions/AnsiConsoleCopyToClipboardAction.java
@@ -1,0 +1,58 @@
+package mnita.ansiconsole.actions;
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.Transferable;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.swt.widgets.Control;
+
+import mnita.ansiconsole.preferences.AnsiConsolePreferenceConstants;
+import mnita.ansiconsole.preferences.AnsiConsolePreferenceUtils;
+import mnita.ansiconsole.utils.AnsiConsoleCopyToClipboardUtil;
+
+/**
+ * @author Martin Lippert
+ */
+public class AnsiConsoleCopyToClipboardAction extends Action implements ClipboardOwner {
+	
+	private Control control;
+	private AnsiConsoleCopyToClipboardUtil clipboardUtil;
+
+	/**
+	 * @param control
+	 */
+	public AnsiConsoleCopyToClipboardAction(Control control) {
+		this.control = control;
+		this.clipboardUtil = new AnsiConsoleCopyToClipboardUtil();
+	}
+
+	@Override
+	public void run() {
+		System.out.println("run it !!!");
+        boolean isAnsiConsoleEnabled = AnsiConsolePreferenceUtils.getBoolean(AnsiConsolePreferenceConstants.PREF_ANSI_CONSOLE_ENABLED);
+
+		if (isAnsiConsoleEnabled) {
+			this.clipboardUtil.copyTextToClipboard(this.control);
+		}
+		else {
+			this.clipboardUtil.copyRawToClipboard(this.control);
+		}
+	}
+
+	@Override
+	public void lostOwnership(Clipboard clipboard, Transferable contents) {
+	}
+	
+}

--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
@@ -1,39 +1,46 @@
 package mnita.ansiconsole.participants;
 
-import mnita.ansiconsole.AnsiConsoleActivator;
-
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsolePageParticipant;
 import org.eclipse.ui.part.IPageBookViewPage;
 
+import mnita.ansiconsole.AnsiConsoleActivator;
+import mnita.ansiconsole.actions.AnsiConsoleCopyToClipboardAction;
+
 public class AnsiConsolePageParticipant implements IConsolePageParticipant {
-    @Override
-    @SuppressWarnings("rawtypes")
-    public Object getAdapter(Class arg) {
-        return null;
-    }
 
-    @Override
-    public void activated() {
-    }
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Object getAdapter(Class arg) {
+		return null;
+	}
 
-    @Override
-    public void deactivated() {
-    }
+	@Override
+	public void activated() {
+	}
 
-    @Override
-    public void dispose() {
-        AnsiConsoleActivator.getDefault().removeViewerWithPageParticipant(this);
-    }
+	@Override
+	public void deactivated() {
+	}
 
-    @Override
-    public void init(IPageBookViewPage page, IConsole console) {
-        if (page.getControl() instanceof StyledText) {
-            StyledText viewer = (StyledText) page.getControl();
-            AnsiConsoleStyleListener myListener = new AnsiConsoleStyleListener();
-            viewer.addLineStyleListener(myListener);
-            AnsiConsoleActivator.getDefault().addViewer(viewer, this);
-        }
-    }
+	@Override
+	public void dispose() {
+		AnsiConsoleActivator.getDefault().removeViewerWithPageParticipant(this);
+	}
+
+	@Override
+	public void init(IPageBookViewPage page, IConsole console) {
+		if (page.getControl() instanceof StyledText) {
+			StyledText viewer = (StyledText) page.getControl();
+			AnsiConsoleStyleListener myListener = new AnsiConsoleStyleListener();
+			viewer.addLineStyleListener(myListener);
+			AnsiConsoleActivator.getDefault().addViewer(viewer, this);
+			
+			AnsiConsoleCopyToClipboardAction copyAction = new AnsiConsoleCopyToClipboardAction(viewer);
+			page.getSite().getActionBars().setGlobalActionHandler(ActionFactory.COPY.getId(), copyAction);
+			page.getSite().getActionBars().updateActionBars();
+		}
+	}
 }

--- a/AnsiConsole/src/mnita/ansiconsole/utils/AnsiConsoleCopyToClipboardUtil.java
+++ b/AnsiConsole/src/mnita/ansiconsole/utils/AnsiConsoleCopyToClipboardUtil.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package mnita.ansiconsole.utils;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Control;
+
+import mnita.ansiconsole.AnsiConsoleUtils;
+
+/**
+ * @author Martin Lippert
+ * (parts of the code moved from AnsiConsoleCopyIconAction)
+ */
+public class AnsiConsoleCopyToClipboardUtil implements ClipboardOwner {
+
+	public void copyTextToClipboard(Control control) {
+		copyToClipboard(control, true);
+	}
+
+	public void copyRawToClipboard(Control control) {
+		copyToClipboard(control, false);
+	}
+
+	protected void copyToClipboard(Control control, boolean removeEscapes) {
+		if (control instanceof StyledText) {
+			StyledText styledText = (StyledText) control;
+			String text = styledText.getSelectionText();
+			if (text.isEmpty()) {
+				text = styledText.getText();
+			}
+
+			if (removeEscapes) {
+				text = text.replaceAll(AnsiConsoleUtils.ESCAPE_SEQUENCE_REGEX, "");
+			}
+
+			Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+			StringSelection stringSelection = new StringSelection(text);
+			clipboard.setContents(stringSelection, this);
+		}
+	}
+
+	@Override
+	public void lostOwnership(Clipboard clipboard, Transferable contents) {
+	}
+
+}


### PR DESCRIPTION
I slightly changed the behavior of the default copy action to that escape characters get removed before the text is copied into the clipboard. This makes it a lo easier to deal with the console, especially when working on apps and doing copy/paste for errors, log output, exceptions, stack traces, etc.

I also changed the behavior of the "copy plain text" icon in the toolbar to always include the escape sequences, so that you can use that action if you need the exact escape characters (which should not be the case that often).

The default copy action takes the settings into account. So if you have the Ansi Console enabled, it removes the escape sequences, otherwise not.

Hope this works for you and can be incorporated into a new version soon.

Thanks!!!