### PR TITLE
Fix the bug that exception stack trace is not rendered properly.

### DIFF
--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
@@ -126,6 +126,13 @@ public class AnsiConsoleStyleListener implements LineStyleListener {
         if (!isAnsiconEnabled)
             return;
 
+        String currentText = event.lineText;
+        Matcher matcher = pattern.matcher(currentText);
+        if (!matcher.find()) {
+            // Return immediately if the pattern is not found.
+            return;
+        }
+
         String currentPalette = AnsiConsolePreferenceUtils.getString(AnsiConsolePreferenceConstants.PREF_COLOR_PALETTE);
         AnsiConsoleColorPalette.setPalette(currentPalette);
         StyleRange defStyle;
@@ -143,9 +150,8 @@ public class AnsiConsoleStyleListener implements LineStyleListener {
 
         lastRangeEnd = 0;
         List<StyleRange> ranges = new ArrayList<StyleRange>();
-        String currentText = event.lineText;
-        Matcher matcher = pattern.matcher(currentText);
-        while (matcher.find()) {
+
+        do {
             int start = matcher.start();
             int end = matcher.end();
 
@@ -169,7 +175,8 @@ public class AnsiConsoleStyleListener implements LineStyleListener {
             lastAttributes = currentAttributes.clone();
 
             addRange(ranges, event.lineOffset + start, end - start, defStyle.foreground, true);
-        }
+        } while (matcher.find());
+
         if (lastRangeEnd != currentText.length())
             addRange(ranges, event.lineOffset + lastRangeEnd, currentText.length() - lastRangeEnd, defStyle.foreground, false);
         lastAttributes = currentAttributes.clone();


### PR DESCRIPTION
After enabled the plugin, when I have code like below, the console is not rendering the exception stack trace properly. This change fixes this.

```
System.out.println("Hello World");
System.out.println("[32mI am a lucky guy[0m");

System.out.println(4/0);
```

**Screenshot for the console output**

![screen shot 2017-12-05 at 4 54 21 pm](https://user-images.githubusercontent.com/7167513/33751793-286fab38-db92-11e7-95ad-6e625d3eac72.png)
