### PR TITLE
fix for issue #50 Compiler output is colored only for a single project

### DIFF
--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
@@ -48,7 +48,7 @@ public class AnsiConsolePageParticipant implements IConsolePageParticipant {
     }
 
     // Find the document associated with the viewer
-    private static IDocument getDocument(StyledText viewer) {
+    public static IDocument getDocument(StyledText viewer) {
         for (Listener listener : viewer.getListeners(ST.LineGetStyle)) {
             if (listener instanceof TypedListener) {
                 Object evenListener = ((TypedListener) listener).getEventListener();


### PR DESCRIPTION
It is necessary to update the IDocument when changing the project. Relevant for new versions of Eclipse.