### PR TITLE
fix c++ console color

### DIFF
--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePageParticipant.java
@@ -41,8 +41,9 @@ public class AnsiConsolePageParticipant implements IConsolePageParticipant {
             if (document == null) {
                 return;
             }
-            AnsiConsoleStyleListener myListener = new AnsiConsoleStyleListener(document);
-            viewer.addLineStyleListener(myListener);
+  
+            viewer.removeLineStyleListener(AnsiConsoleStyleListener.INSTANCE);
+            viewer.addLineStyleListener(AnsiConsoleStyleListener.INSTANCE);
             AnsiConsoleActivator.getDefault().addViewer(viewer, this);
         }
     }

--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePositionUpdater.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsolePositionUpdater.java
@@ -1,0 +1,86 @@
+package mnita.ansiconsole.participants;
+
+import java.util.regex.Matcher;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.BadPositionCategoryException;
+import org.eclipse.jface.text.DefaultPositionUpdater;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+
+import mnita.ansiconsole.AnsiConsoleUtils;
+import mnita.ansiconsole.preferences.AnsiConsolePreferenceUtils;
+import mnita.ansiconsole.utils.AnsiConsoleAttributes;
+import mnita.ansiconsole.utils.AnsiConsoleColorPalette;
+
+public class AnsiConsolePositionUpdater extends DefaultPositionUpdater {
+
+	public static final String POSITION_NAME = "ansi_color";
+
+	// store the last processed attributes
+	AnsiConsoleAttributes attributes = AnsiConsoleAttributes.DEFAULT;
+	
+	public AnsiConsolePositionUpdater(IDocument document) {
+		super(POSITION_NAME);
+
+		AnsiConsoleColorPalette.setPalette(AnsiConsolePreferenceUtils.getPreferredPalette());
+		update(document, 0, document.get());
+	}
+
+	public void update(IDocument document, final int offset, final String text) {
+
+		if (text == null || text.isEmpty())
+			return;
+		
+		final Matcher matcher = AnsiConsoleUtils.ESCAPE_SEQUENCE_REGEX_TXT.matcher(text);
+
+
+		try {
+	
+			int escapeOffet = 0;
+
+			while (matcher.find()) {
+				int start = matcher.start();
+				String group = matcher.group();
+
+				if (attributes != AnsiConsoleAttributes.DEFAULT && start > escapeOffet)
+					document.addPosition(POSITION_NAME,
+							new AnsiPosition(escapeOffet + offset, start - escapeOffet, attributes));
+
+
+				// escape the code
+				document.addPosition(POSITION_NAME, new AnsiPosition(start + offset, group.length()));
+
+				// update the attributes
+				attributes = attributes.apply(group);
+
+				// update the offset
+				escapeOffet = start + group.length();
+
+			}
+			// if the attributes is of interest and length is not null add a position
+			if (attributes != AnsiConsoleAttributes.DEFAULT && text.length() > escapeOffet) {
+				AnsiPosition pos = new AnsiPosition(escapeOffet + offset, text.length() - escapeOffet, attributes);
+				document.addPosition(POSITION_NAME, pos);
+			}
+
+		} catch (BadPositionCategoryException | BadLocationException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+
+	@Override
+	public void update(DocumentEvent event) {
+		super.update(event);
+		
+		if (!AnsiConsolePreferenceUtils.isAnsiConsoleEnabled())
+			return;
+
+		
+		
+		update(event.getDocument(), event.getOffset(), event.getText());
+	}
+
+}

--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiConsoleStyleListener.java
@@ -1,250 +1,142 @@
 package mnita.ansiconsole.participants;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.regex.Matcher;
 
-import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPositionCategoryException;
-import org.eclipse.jface.text.DefaultPositionUpdater;
-import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.IPositionUpdater;
 import org.eclipse.jface.text.Position;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.LineStyleEvent;
 import org.eclipse.swt.custom.LineStyleListener;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.GlyphMetrics;
 
-import mnita.ansiconsole.AnsiConsoleUtils;
 import mnita.ansiconsole.preferences.AnsiConsolePreferenceUtils;
-import mnita.ansiconsole.utils.AnsiConsoleAttributes;
-import mnita.ansiconsole.utils.AnsiConsoleColorPalette;
 
-public class AnsiConsoleStyleListener implements LineStyleListener, IPositionUpdater {
-    private static final Font MONO_FONT = new Font(null, "Monospaced", 6, SWT.NORMAL);
+public class AnsiConsoleStyleListener implements LineStyleListener {
 
-    private final DefaultPositionUpdater defaultPositionUpdater = new DefaultPositionUpdater(AnsiPosition.POSITION_NAME);
-    private final HashMap<Integer, List<StyleRange>> offsetToStyleRangeCache = new HashMap<>();
-    private IDocument document;
-    private boolean documentEverScanned = false;
-    private int oldEventTime;
+	public static AnsiConsoleStyleListener INSTANCE = new AnsiConsoleStyleListener();
 
-    private AnsiConsoleAttributes lastVisibleAttribute = new AnsiConsoleAttributes();
+	private AnsiConsoleStyleListener() {
+	}
 
-    public AnsiConsoleStyleListener(IDocument document) {
-        setDocument(document);
-        AnsiConsoleColorPalette.setPalette(AnsiConsolePreferenceUtils.getPreferredPalette());
-    }
+	private IDocument getDocument(LineStyleEvent event) {
+		if (event.getSource() instanceof StyledText) {
 
-    private void setDocument(IDocument newDocument) {
-        offsetToStyleRangeCache.clear();
-        documentEverScanned = false;
-        document = newDocument;
-        document.addPositionCategory(AnsiPosition.POSITION_NAME);
-        if (!hasPositionUpdater(this))
-            document.addPositionUpdater(this);
-    }
+			StyledText text = (StyledText) event.getSource();
+			return AnsiConsolePageParticipant.getDocument(text);
+		}
+		return null;
+	}
 
-    public boolean hasPositionUpdater(IPositionUpdater updater) {
-        for (IPositionUpdater posUpdater : document.getPositionUpdaters())
-            if (posUpdater == updater)
-                return true;
-        return false;
-    }
+	@Override
+	public void lineGetStyle(LineStyleEvent event) {
 
-    private static void addRange(List<StyleRange> ranges, int start, int length,
-            AnsiConsoleAttributes attributes, Color foreground, boolean isCode) {
+		if (!AnsiConsolePreferenceUtils.isAnsiConsoleEnabled())
+			return;
 
-        final StyleRange range = new StyleRange(start, length, foreground, null);
-        AnsiConsoleAttributes.updateRangeStyle(range, attributes);
-        if (isCode) {
-            if (AnsiConsolePreferenceUtils.showAnsiEscapes()) {
-                range.font = MONO_FONT; // Show the codes in small, monospaced font
-            } else {
-                range.metrics = new GlyphMetrics(0, 0, 0); // Hide the codes
-            }
-        }
-        ranges.add(range);
-    }
+		IDocument document = getDocument(event);
 
-    @Override
-    public void lineGetStyle(LineStyleEvent event) {
-        if (event == null || event.lineText == null || event.lineText.length() == 0)
-            return;
+		if (document == null || document.getLength() == 0)
+			return;
 
-        if (document == null)
-            return;
+		// retrieve ansi positions
+		Position[] positions;
+		try {
+			positions = document.getPositions(AnsiConsolePositionUpdater.POSITION_NAME);
+		} catch (BadPositionCategoryException e1) {
+			// this exception is raised when the document is processed for the first time
 
-        if (!AnsiConsolePreferenceUtils.isAnsiConsoleEnabled())
-            return;
+			// init the PositionCategory and AnsiConsolePositionUpdater for this document
+			document.addPositionCategory(AnsiConsolePositionUpdater.POSITION_NAME);
+			document.addPositionUpdater(new AnsiConsolePositionUpdater(document));
 
-        // If user selected another project (for new versions of Eclipse)
-        if (oldEventTime != event.time && event.getSource() instanceof StyledText) {
-            oldEventTime = event.time;
-            StyledText text = (StyledText) event.getSource();
-            IDocument newDocument = AnsiConsolePageParticipant.getDocument(text);
-            if (newDocument != null && !newDocument.equals(document)) {
-                setDocument(newDocument);
-            }
-        }
+			// positions should be initialized now
+			try {
+				positions = document.getPositions(AnsiConsolePositionUpdater.POSITION_NAME);
+			} catch (BadPositionCategoryException e) {
+				return;
+			}
+		}
 
-        final int eventOffset = event.lineOffset;
-        final int eventLength = event.lineText.length();
-        final List<StyleRange> cachedRanges = offsetToStyleRangeCache.get(eventOffset);
-        if (cachedRanges != null) {
-            event.styles = cachedRanges.toArray(new StyleRange[0]);
-            return;
-        }
-        if (event.styles == null) { // It looks that in some cases this comes in as null
-            event.styles = new StyleRange[0];
-        }
+		List<StyleRange> styles = new ArrayList<>(4);
 
-        if (!documentEverScanned) {
-            calculateDocumentAnsiPositions(document, 0, 0, null);
-        }
+		// keep existing styles if any
+		if (event.styles != null)
+			Collections.addAll(styles, event.styles);
 
-        Position[] positions;
-        try {
-            positions = document.getPositions(AnsiPosition.POSITION_NAME);
-        } catch (BadPositionCategoryException e) {
-            return;
-        }
+		// process positions that overlap with the current line
+		if (processPositions(styles, event.lineOffset, event.lineText.length(), positions))
+			// update event styles
+			event.styles = styles.toArray(new StyleRange[styles.size()]);
 
-        if (positions.length == 0)
-            return;
+	}
 
-        final Color errorColor = AnsiConsolePreferenceUtils.getDebugConsoleErrorColor();
-        Color foregroundColor = AnsiConsolePreferenceUtils.getDebugConsoleFgColor();
-        if (AnsiConsolePreferenceUtils.tryPreservingStdErrColor()) {
-            for (StyleRange range : event.styles) {
-                if (errorColor.equals(range.foreground)) {
-                    foregroundColor = errorColor;
-                    break;
-                }
-            }
-        }
+	/**
+	 * Process the positions overlapping the given range
+	 *
+	 * @param styles    the result list of StyleRange
+	 * @param offset    the offset of the range
+	 * @param length    the length of the range
+	 * @param positions the positions to search
+	 */
+	private boolean processPositions(List<StyleRange> styles, int offset, int length, Position[] positions) {
 
-        final List<StyleRange> ranges = new ArrayList<>();
-        AnsiConsoleAttributes prevAttr = lastVisibleAttribute;
-        int prevPos = eventOffset;
+		if (positions.length == 0)
+			return false;
 
-        for (Position position : positions) {
-            AnsiPosition apos = (AnsiPosition) position;
-            if (apos.getOffset() > eventOffset + eventLength) // we passed the end of line, stop searching
-                break;
-            if (apos.overlapsWith(eventOffset, eventLength)) {
-                if (apos.offset != prevPos) {
-                    addRange(ranges, prevPos, apos.offset - prevPos, prevAttr, foregroundColor, false);
-                }
-                addRange(ranges, apos.offset, apos.length, apos.attributes, foregroundColor, true);
-                prevPos = apos.offset + apos.length;
-            }
-            if (apos.attributes != null) {
-                // Attributes can be null for non \e[..m escapes, for example \e[K
-                // Those kind of escape sequences don't affect the attributes.
-                prevAttr = apos.attributes;
-            }
-        }
+		int rangeEnd = offset + length;
+		int left = 0;
+		int right = positions.length - 1;
+		int mid = 0;
+		Position position;
 
-        if (!ranges.isEmpty()) {
-        	addRange(ranges, prevPos, eventOffset + eventLength - prevPos, prevAttr, foregroundColor, false);
-            // Copy the links that might already exist
-            for (StyleRange range : event.styles) {
-                if (AnsiConsolePreferenceUtils.getHyperlinkColor().equals(range.foreground))
-                    ranges.add(range);
-            }
-            offsetToStyleRangeCache.put(eventOffset, ranges);
-            event.styles = ranges.toArray(new StyleRange[0]);
-        }
-    }
+		while (left < right) {
 
-    private static List<AnsiPosition> findPositions(int offset, String currentText) {
-        final List<AnsiPosition> result = new ArrayList<>();
-        final Matcher matcher = AnsiConsoleUtils.ESCAPE_SEQUENCE_REGEX_TXT.matcher(currentText);
-        while (matcher.find()) {
-            int start = matcher.start();
-            String group = matcher.group();
-            result.add(new AnsiPosition(start + offset, group));
-        }
-        return result;
-    }
+			mid = (left + right) / 2;
 
-    /**
-     * We scan newly appended text, or the full document the first time.
-     *
-     * Although in a general an IDocument can also replace text, or insert text in the middle (or beginning)
-     * that would complicate things a lot.
-     * But this is a console output, so I don't expect such a thing to happen.
-     * We only expect to append (at the end), or remove from the beginning (when the doc size > console buffer size)
-     *   offset: 0, length: 0, "something" => Appended at beginning of doc (the doc was empty)
-     *   offset:42, length: 0, "something" => Appended at end of doc. 42 was doc size before append.
-     *   offset:0, length: 100, ""         => Removed the first 100 characters (replace with "" == remove)
-     *
-     * @param eventDocument The document
-     * @param offset        Where was the text added. 0 => might mean remove, or the first content added
-     * @param length        The length of the text replaced. 0 if append, != if removed (from the beginning)
-     * @param text          For insert / append, this is the new text. For delete, empty string.
-     */
-    private void calculateDocumentAnsiPositions(IDocument eventDocument, int offset, int length, String text) {
-        if (text == null)
-            text = eventDocument.get();
+			position = positions[mid];
+			if (rangeEnd < position.getOffset()) {
+				if (left == mid) {
+					right = left;
+				} else {
+					right = mid - 1;
+				}
+			} else if (offset > (position.getOffset() + position.getLength() - 1)) {
+				if (right == mid) {
+					left = right;
+				} else {
+					left = mid + 1;
+				}
+			} else {
+				left = right = mid;
+			}
+		}
 
-        if (length != 0) { // This is the length of the text replaced. If not zero then this is not append, is replace.
-            return;
-        }
-        // First time or the appended text is at the end (so it is not inserted text).
-        if (documentEverScanned && offset + text.length() != eventDocument.getLength()) {
-            return;
-        }
-        documentEverScanned = true;
-        try {
-            final int lineCount = eventDocument.getNumberOfLines(offset, length);
-            for (int i = 0; i < lineCount; i++) {
-                List<AnsiPosition> newPos = findPositions(offset, text);
-                for (AnsiPosition apos : newPos) {
-                    eventDocument.addPosition(AnsiPosition.POSITION_NAME, apos);
-                }
-            }
-        } catch (BadPositionCategoryException | BadLocationException e) {
-            e.printStackTrace();
-        }
-    }
+		int index = left - 1;
+		if (index >= 0) {
+			position = positions[index];
+			while (index >= 0 && (position.getOffset() + position.getLength()) > offset) {
+				index--;
+				if (index > 0) {
+					position = positions[index];
+				}
+			}
+		}
+		index++;
+		position = positions[index];
+		boolean found = false;
+		while (index < positions.length && (position.getOffset() < rangeEnd)) {
+			styles.add(((AnsiPosition) position).range);
+			found = true;
+			index++;
+			if (index < positions.length) {
+				position = positions[index];
+			}
+		}
+		return found;
 
-    @Override
-    public void update(DocumentEvent event) {
-        // Make sure we don't do anything if disabled
-        if (!AnsiConsolePreferenceUtils.isAnsiConsoleEnabled())
-            return;
+	}
 
-        final IDocument eventDocument = event.getDocument();
-
-        final int offset = event.getOffset();
-        final int length = event.getLength();
-        final String text = event.getText();
-        try {
-            if (offset == 0 && length != 0) { // This removes the beginning. We scan to find and save the last style.
-                for (Position pos : eventDocument.getPositions(AnsiPosition.POSITION_NAME)) {
-                    if (pos.offset >= length)
-                        break;
-                    AnsiConsoleAttributes attributes = ((AnsiPosition) pos).attributes;
-                    if (attributes != null) {
-                        lastVisibleAttribute = attributes;
-                    }
-                }
-            }
-            defaultPositionUpdater.update(event);
-            // This will only do something on new text (appended)
-            calculateDocumentAnsiPositions(eventDocument, offset, length, text);
-            // Would probably be possible to re-calculate things. But let's measure first (premature optimization and all that :-)
-            offsetToStyleRangeCache.clear();
-        } catch (BadPositionCategoryException e) {
-            e.printStackTrace();
-        }
-    }
 }

--- a/AnsiConsole/src/mnita/ansiconsole/participants/AnsiPosition.java
+++ b/AnsiConsole/src/mnita/ansiconsole/participants/AnsiPosition.java
@@ -1,164 +1,46 @@
 package mnita.ansiconsole.participants;
 
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CONCEAL_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CONCEAL_ON;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CROSSOUT_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CROSSOUT_ON;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_FRAMED_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_FRAMED_ON;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_BRIGHT;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_FAINT;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_NORMAL;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_ITALIC;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_ITALIC_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_NEGATIVE_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_NEGATIVE_ON;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_RESET;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE_DOUBLE;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE_OFF;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_FIRST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_LAST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_RESET;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_FIRST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_LAST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_RESET;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_INTENSITY_DELTA;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND_FIRST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND_LAST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND_FIRST;
-import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND_LAST;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.eclipse.jface.text.Position;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.GlyphMetrics;
 
-import mnita.ansiconsole.AnsiConsoleUtils;
+import mnita.ansiconsole.preferences.AnsiConsolePreferenceUtils;
 import mnita.ansiconsole.utils.AnsiConsoleAttributes;
-import mnita.ansiconsole.utils.AnsiConsoleColorPalette;
 
 public class AnsiPosition extends Position {
-    public static final String POSITION_NAME = "ansi_color";
 
-    private static final AnsiConsoleAttributes current = new AnsiConsoleAttributes();
+	private static final Font MONO_FONT = new Font(null, "Monospaced", 6, SWT.NORMAL);
 
-    public final AnsiConsoleAttributes attributes;
-    public final String text;
+	public final StyleRange range;
 
-    public AnsiPosition(int offset, String text) {
-        super(offset, text == null ? 0 : text.length());
-        this.text = text == null ? "" : text;
-        this.attributes = updateAttributes();
-    }
+	/**
+	 * Build an ansi position for a text area with custom attributes
+	 * @param offset the position offset
+	 * @param length the position length
+	 * @param attributes the position ansi attributes
+	 */
+	public AnsiPosition(int offset, int length, AnsiConsoleAttributes attributes) {
+		super(offset, length);
 
-    @Override
-    public String toString() {
-        return String.format("AnsiPosition:{ offset:%d length:%d text:\"%s\" attr:\"%s\" }", offset, length, text, attributes);
-    }
+		this.range = new StyleRange(offset, length, null, null);
+		AnsiConsoleAttributes.updateRangeStyle(range, attributes);
+	}
+/**
+ * Build an ansi position for an escape code
+ * @param offset the position offset
+ * @param length the position length
+ */
+	public AnsiPosition(int offset, int length) {
+		super(offset, length);
 
-    // Takes a string that looks like this: int [ ';' int] and returns a list of the integers
-    private static List<Integer> parseSemicolonSeparatedIntList(String text) {
-        final List<Integer> result = new ArrayList<>(10);
-        int crtValue = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char ch = text.charAt(i);
-            if (ch >= '0' && ch <= '9') {
-                crtValue *= 10;
-                crtValue += ch - '0';
-            } else {
-                result.add(crtValue);
-                crtValue = 0;
-            }
-        }
-        result.add(crtValue);
-        return result;
-    }
-
-    private AnsiConsoleAttributes updateAttributes() {
-        char code = text.charAt(text.length() - 1);
-        if (code == AnsiConsoleUtils.ESCAPE_SGR) {
-            String theEscape = text.substring(2, text.length() - 1);
-            // Select Graphic Rendition (SGR) escape sequence
-            interpretCommand(parseSemicolonSeparatedIntList(theEscape));
-            return AnsiConsoleAttributes.from(current);
-        }
-        return null;
-    }
-
-    private static void interpretCommand(List<Integer> nCommands) {
-
-        Iterator<Integer> iter = nCommands.iterator();
-        while (iter.hasNext()) {
-            int nCmd = iter.next();
-            switch (nCmd) {
-                case COMMAND_ATTR_RESET:             current.reset(); break;
-
-                case COMMAND_ATTR_INTENSITY_BRIGHT:  current.bold = true; break;
-                case COMMAND_ATTR_INTENSITY_FAINT: // Intentional fallthrough
-                case COMMAND_ATTR_INTENSITY_NORMAL:  current.bold = false; break;
-
-                case COMMAND_ATTR_ITALIC:            current.italic = true; break;
-                case COMMAND_ATTR_ITALIC_OFF:        current.italic = false; break;
-
-                case COMMAND_ATTR_UNDERLINE:         current.underline = SWT.UNDERLINE_SINGLE; break;
-                case COMMAND_ATTR_UNDERLINE_DOUBLE:  current.underline = SWT.UNDERLINE_DOUBLE; break;
-                case COMMAND_ATTR_UNDERLINE_OFF:     current.underline = AnsiConsoleAttributes.UNDERLINE_NONE; break;
-
-                case COMMAND_ATTR_CROSSOUT_ON:       current.strike = true; break;
-                case COMMAND_ATTR_CROSSOUT_OFF:      current.strike = false; break;
-
-                case COMMAND_ATTR_NEGATIVE_ON:       current.invert = true; break;
-                case COMMAND_ATTR_NEGATIVE_OFF:      current.invert = false; break;
-
-                case COMMAND_ATTR_CONCEAL_ON:        current.conceal = true; break;
-                case COMMAND_ATTR_CONCEAL_OFF:       current.conceal = false; break;
-
-                case COMMAND_ATTR_FRAMED_ON:         current.framed = true; break;
-                case COMMAND_ATTR_FRAMED_OFF:        current.framed = false; break;
-
-                case COMMAND_COLOR_FOREGROUND_RESET: current.currentFgColor = null; break;
-                case COMMAND_COLOR_BACKGROUND_RESET: current.currentBgColor = null; break;
-
-                case COMMAND_HICOLOR_FOREGROUND:
-                case COMMAND_HICOLOR_BACKGROUND: // {esc}[48;5;{color}m
-                    int color = -1;
-                    int nMustBe2or5 = iter.hasNext() ? iter.next() : -1;
-                    if (nMustBe2or5 == 5) { // 256 colors
-                        color = iter.hasNext() ? iter.next() : -1;
-                        if (!AnsiConsoleColorPalette.isValidIndex(color))
-                            color = -1;
-                    } else if (nMustBe2or5 == 2) { // rgb colors
-                        int r = iter.hasNext() ? iter.next() : -1;
-                        int g = iter.hasNext() ? iter.next() : -1;
-                        int b = iter.hasNext() ? iter.next() : -1;
-                        color = AnsiConsoleColorPalette.hackRgb(r, g, b);
-                    }
-                    if (color != -1) {
-                        if (nCmd == COMMAND_HICOLOR_FOREGROUND)
-                            current.currentFgColor = color;
-                        else
-                            current.currentBgColor = color;
-                    }
-                    break;
-
-                case -1: break; // do nothing
-
-                default:
-                    if (nCmd >= COMMAND_COLOR_FOREGROUND_FIRST && nCmd <= COMMAND_COLOR_FOREGROUND_LAST) // text color
-                        current.currentFgColor = nCmd - COMMAND_COLOR_FOREGROUND_FIRST;
-                    else if (nCmd >= COMMAND_COLOR_BACKGROUND_FIRST && nCmd <= COMMAND_COLOR_BACKGROUND_LAST) // background color
-                        current.currentBgColor = nCmd - COMMAND_COLOR_BACKGROUND_FIRST;
-                    else if (nCmd >= COMMAND_HICOLOR_FOREGROUND_FIRST && nCmd <= COMMAND_HICOLOR_FOREGROUND_LAST) // text color
-                        current.currentFgColor = nCmd - COMMAND_HICOLOR_FOREGROUND_FIRST + COMMAND_COLOR_INTENSITY_DELTA;
-                    else if (nCmd >= COMMAND_HICOLOR_BACKGROUND_FIRST && nCmd <= COMMAND_HICOLOR_BACKGROUND_LAST) // background color
-                        current.currentBgColor = nCmd - COMMAND_HICOLOR_BACKGROUND_FIRST + COMMAND_COLOR_INTENSITY_DELTA;
-            }
-        }
-    }
+		this.range = new StyleRange(offset, length, null, null);
+		if (AnsiConsolePreferenceUtils.showAnsiEscapes()) {
+			range.font = MONO_FONT; // Show the codes in small, monospaced font
+		} else {
+			range.metrics = new GlyphMetrics(0, 0, 0); // Hide the codes
+		}
+	}
 
 }

--- a/AnsiConsole/src/mnita/ansiconsole/utils/AnsiConsoleAttributes.java
+++ b/AnsiConsole/src/mnita/ansiconsole/utils/AnsiConsoleAttributes.java
@@ -1,176 +1,386 @@
 package mnita.ansiconsole.utils;
 
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CONCEAL_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CONCEAL_ON;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CROSSOUT_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_CROSSOUT_ON;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_FRAMED_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_FRAMED_ON;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_BRIGHT;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_FAINT;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_INTENSITY_NORMAL;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_ITALIC;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_ITALIC_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_NEGATIVE_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_NEGATIVE_ON;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_RESET;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE_DOUBLE;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_ATTR_UNDERLINE_OFF;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_FIRST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_LAST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_BACKGROUND_RESET;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_FIRST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_LAST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_FOREGROUND_RESET;
 import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_COLOR_INTENSITY_DELTA;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND_FIRST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_BACKGROUND_LAST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND_FIRST;
+import static mnita.ansiconsole.utils.AnsiCommands.COMMAND_HICOLOR_FOREGROUND_LAST;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 
+import mnita.ansiconsole.AnsiConsoleUtils;
 import mnita.ansiconsole.preferences.AnsiConsolePreferenceUtils;
 
 public class AnsiConsoleAttributes {
-    public static final int UNDERLINE_NONE = -1; // nothing in SWT, a bit of an abuse
+	public static final int UNDERLINE_NONE = -1; // nothing in SWT, a bit of an abuse
 
-    // If you change any of these also update reset()
-    public Integer currentBgColor;
-    public Integer currentFgColor;
-    public int underline;
-    public boolean bold;
-    public boolean italic;
-    public boolean invert;
-    public boolean conceal;
-    public boolean strike;
-    public boolean framed;
+	public static final AnsiConsoleAttributes DEFAULT = new AnsiConsoleAttributes();
 
-    public AnsiConsoleAttributes() {
-        reset();
-    }
+	// If you change any of these also update reset()
+	public Integer currentBgColor;
+	public Integer currentFgColor;
+	public int underline;
+	public boolean bold;
+	public boolean italic;
+	public boolean invert;
+	public boolean conceal;
+	public boolean strike;
+	public boolean framed;
 
-    public void reset() {
-        currentBgColor = null;
-        currentFgColor = null;
-        underline = UNDERLINE_NONE;
-        bold = false;
-        italic = false;
-        invert = false;
-        conceal = false;
-        strike = false;
-        framed = false;
-    }
+	private AnsiConsoleAttributes() {
+		reset();
+	}
 
-    public static AnsiConsoleAttributes from(AnsiConsoleAttributes other) {
-        AnsiConsoleAttributes result = new AnsiConsoleAttributes();
-        if (other != null) {
-            result.currentBgColor = other.currentBgColor;
-            result.currentFgColor = other.currentFgColor;
-            result.underline = other.underline;
-            result.bold = other.bold;
-            result.italic = other.italic;
-            result.invert = other.invert;
-            result.conceal = other.conceal;
-            result.strike = other.strike;
-            result.framed = other.framed;
-        }
-        return result;
-    }
+	public void reset() {
+		currentBgColor = null;
+		currentFgColor = null;
+		underline = UNDERLINE_NONE;
+		bold = false;
+		italic = false;
+		invert = false;
+		conceal = false;
+		strike = false;
+		framed = false;
+	}
 
-    @Override
-    public String toString() {
-        StringBuilder result = new StringBuilder();
-        if (currentBgColor != null) result.append("Bg" + currentBgColor);
-        if (currentFgColor != null) result.append("Fg" + currentFgColor);
-        if (underline != UNDERLINE_NONE) result.append("_");
-        if (bold) result.append("B");
-        if (italic) result.append("I");
-        if (invert) result.append("!");
-        if (conceal) result.append("H");
-        if (strike) result.append("-");
-        if (framed) result.append("[]");
-        return result.toString();
-    }
+	public static AnsiConsoleAttributes from(AnsiConsoleAttributes other) {
+		AnsiConsoleAttributes result = new AnsiConsoleAttributes();
+		if (other != null) {
+			result.currentBgColor = other.currentBgColor;
+			result.currentFgColor = other.currentFgColor;
+			result.underline = other.underline;
+			result.bold = other.bold;
+			result.italic = other.italic;
+			result.invert = other.invert;
+			result.conceal = other.conceal;
+			result.strike = other.strike;
+			result.framed = other.framed;
+		}
+		return result;
+	}
 
-    private static Color hiliteRgbColor(Color color) {
-        if (color == null)
-            return ColorCache.get(new RGB(0xff, 0xff, 0xff));
-        int red = color.getRed() * 2;
-        int green = color.getGreen() * 2;
-        int blue = color.getBlue() * 2;
+	public boolean equals(AnsiConsoleAttributes other) {
 
-        if (red > 0xff)   red = 0xff;
-        if (green > 0xff) green = 0xff;
-        if (blue > 0xff)  blue = 0xff;
+		return other != null && currentBgColor == other.currentBgColor && currentFgColor == other.currentFgColor
+				&& underline == other.underline && bold == other.bold && italic == other.italic
+				&& invert == other.invert && conceal == other.conceal && strike == other.strike
+				&& framed == other.framed;
+	}
 
-        return ColorCache.get(new RGB(red, green, blue)); // here
-    }
+	@Override
+	public String toString() {
+		StringBuilder result = new StringBuilder();
+		if (currentBgColor != null)
+			result.append("Bg" + currentBgColor);
+		if (currentFgColor != null)
+			result.append("Fg" + currentFgColor);
+		if (underline != UNDERLINE_NONE)
+			result.append("_");
+		if (bold)
+			result.append("B");
+		if (italic)
+			result.append("I");
+		if (invert)
+			result.append("!");
+		if (conceal)
+			result.append("H");
+		if (strike)
+			result.append("-");
+		if (framed)
+			result.append("[]");
+		return result.toString();
+	}
 
-    // This function maps from the current attributes as "described" by escape sequences to real,
-    // Eclipse console specific attributes (resolving color palette, default colors, etc.)
-    public static void updateRangeStyle(StyleRange range, AnsiConsoleAttributes attribute) {
-        if (attribute == null)
-            return;
+	private static Color hiliteRgbColor(Color color) {
+		if (color == null)
+			return ColorCache.get(new RGB(0xff, 0xff, 0xff));
+		int red = color.getRed() * 2;
+		int green = color.getGreen() * 2;
+		int blue = color.getBlue() * 2;
 
-        AnsiConsoleAttributes tempAttrib = AnsiConsoleAttributes.from(attribute);
+		if (red > 0xff)
+			red = 0xff;
+		if (green > 0xff)
+			green = 0xff;
+		if (blue > 0xff)
+			blue = 0xff;
 
-        boolean hilite = false;
+		return ColorCache.get(new RGB(red, green, blue)); // here
+	}
 
-        if (AnsiConsolePreferenceUtils.useWindowsMapping()) {
-            if (tempAttrib.bold) {
-                tempAttrib.bold = false; // not supported, rendered as intense, already done that
-                hilite = true;
-            }
-            if (tempAttrib.italic) {
-                tempAttrib.italic = false;
-                tempAttrib.invert = true;
-            }
-            tempAttrib.underline = UNDERLINE_NONE; // not supported on Windows
-            tempAttrib.strike = false; // not supported on Windows
-            tempAttrib.framed = false; // not supported on Windows
-        }
+	// This function maps from the current attributes as "described" by escape
+	// sequences to real,
+	// Eclipse console specific attributes (resolving color palette, default colors,
+	// etc.)
+	public static void updateRangeStyle(StyleRange range, AnsiConsoleAttributes attribute) {
+		if (attribute == null)
+			return;
 
-        // Prepare the foreground color
-        if (hilite) {
-            if (tempAttrib.currentFgColor == null) {
-                range.foreground = AnsiConsolePreferenceUtils.getDebugConsoleFgColor();
-                range.foreground = hiliteRgbColor(range.foreground);
-            } else {
-                if (tempAttrib.currentFgColor < COMMAND_COLOR_INTENSITY_DELTA)
-                    range.foreground = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentFgColor + COMMAND_COLOR_INTENSITY_DELTA));
-                else
-                    range.foreground = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentFgColor));
-            }
-        } else {
-            if (tempAttrib.currentFgColor != null)
-                range.foreground = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentFgColor));
-        }
+		AnsiConsoleAttributes tempAttrib = AnsiConsoleAttributes.from(attribute);
 
-        // Prepare the background color
-        if (tempAttrib.currentBgColor != null)
-            range.background = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentBgColor));
+		boolean hilite = false;
 
-        // These two still mess with the foreground/background colors
-        // We need to solve them before we use them for strike/underline/frame colors
-        if (tempAttrib.invert) {
-            if (range.foreground == null)
-                range.foreground = AnsiConsolePreferenceUtils.getDebugConsoleFgColor();
-            if (range.background == null)
-                range.background = AnsiConsolePreferenceUtils.getDebugConsoleBgColor();
-            Color tmp = range.background;
-            range.background = range.foreground;
-            range.foreground = tmp;
-        }
+		if (AnsiConsolePreferenceUtils.useWindowsMapping()) {
+			if (tempAttrib.bold) {
+				tempAttrib.bold = false; // not supported, rendered as intense, already done that
+				hilite = true;
+			}
+			if (tempAttrib.italic) {
+				tempAttrib.italic = false;
+				tempAttrib.invert = true;
+			}
+			tempAttrib.underline = UNDERLINE_NONE; // not supported on Windows
+			tempAttrib.strike = false; // not supported on Windows
+			tempAttrib.framed = false; // not supported on Windows
+		}
 
-        if (tempAttrib.conceal) {
-            if (range.background == null)
-                range.background = AnsiConsolePreferenceUtils.getDebugConsoleBgColor();
-            range.foreground = range.background;
-        }
+		// Prepare the foreground color
+		if (hilite) {
+			if (tempAttrib.currentFgColor == null) {
+				range.foreground = AnsiConsolePreferenceUtils.getDebugConsoleFgColor();
+				range.foreground = hiliteRgbColor(range.foreground);
+			} else {
+				if (tempAttrib.currentFgColor < COMMAND_COLOR_INTENSITY_DELTA)
+					range.foreground = ColorCache.get(AnsiConsoleColorPalette
+							.getColor(tempAttrib.currentFgColor + COMMAND_COLOR_INTENSITY_DELTA));
+				else
+					range.foreground = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentFgColor));
+			}
+		} else {
+			if (tempAttrib.currentFgColor != null)
+				range.foreground = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentFgColor));
+		}
 
-        range.font = null;
-        range.fontStyle = SWT.NORMAL;
-        // Prepare the rest of the attributes
-        if (tempAttrib.bold)
-            range.fontStyle |= SWT.BOLD;
+		// Prepare the background color
+		if (tempAttrib.currentBgColor != null)
+			range.background = ColorCache.get(AnsiConsoleColorPalette.getColor(tempAttrib.currentBgColor));
 
-        if (tempAttrib.italic)
-            range.fontStyle |= SWT.ITALIC;
+		// These two still mess with the foreground/background colors
+		// We need to solve them before we use them for strike/underline/frame colors
+		if (tempAttrib.invert) {
+			if (range.foreground == null)
+				range.foreground = AnsiConsolePreferenceUtils.getDebugConsoleFgColor();
+			if (range.background == null)
+				range.background = AnsiConsolePreferenceUtils.getDebugConsoleBgColor();
+			Color tmp = range.background;
+			range.background = range.foreground;
+			range.foreground = tmp;
+		}
 
-        if (tempAttrib.underline != UNDERLINE_NONE) {
-            range.underline = true;
-            range.underlineColor = range.foreground;
-            range.underlineStyle = tempAttrib.underline;
-        } else {
-            range.underline = false;
-        }
+		if (tempAttrib.conceal) {
+			if (range.background == null)
+				range.background = AnsiConsolePreferenceUtils.getDebugConsoleBgColor();
+			range.foreground = range.background;
+		}
 
-        range.strikeout = tempAttrib.strike;
-        range.strikeoutColor = range.foreground;
+		range.font = null;
+		range.fontStyle = SWT.NORMAL;
+		// Prepare the rest of the attributes
+		if (tempAttrib.bold)
+			range.fontStyle |= SWT.BOLD;
 
-        if (tempAttrib.framed) {
-            range.borderStyle = SWT.BORDER_SOLID;
-            range.borderColor = range.foreground;
-        } else {
-            range.borderStyle = SWT.NONE;
-        }
-    }
+		if (tempAttrib.italic)
+			range.fontStyle |= SWT.ITALIC;
+
+		if (tempAttrib.underline != UNDERLINE_NONE) {
+			range.underline = true;
+			range.underlineColor = range.foreground;
+			range.underlineStyle = tempAttrib.underline;
+		} else {
+			range.underline = false;
+		}
+
+		range.strikeout = tempAttrib.strike;
+		range.strikeoutColor = range.foreground;
+
+		if (tempAttrib.framed) {
+			range.borderStyle = SWT.BORDER_SOLID;
+			range.borderColor = range.foreground;
+		} else {
+			range.borderStyle = SWT.NONE;
+		}
+	}
+
+	/**
+	 * Apply an ansi escape code to the current attribute
+	 * @param ansiCode the ansi code
+	 * @return the resulting attributes
+	 */
+	public AnsiConsoleAttributes apply(String ansiCode) {
+		char code = ansiCode.charAt(ansiCode.length() - 1);
+		if (code == AnsiConsoleUtils.ESCAPE_SGR) {
+			String theEscape = ansiCode.substring(2, ansiCode.length() - 1);
+
+			AnsiConsoleAttributes current = AnsiConsoleAttributes.from(this);
+			// Select Graphic Rendition (SGR) escape sequence
+			current.interpretCommand(parseSemicolonSeparatedIntList(theEscape));
+			if (current.equals(AnsiConsoleAttributes.DEFAULT))
+				return AnsiConsoleAttributes.DEFAULT;
+
+			return current;
+		}
+		return this;
+	}
+
+	// Takes a string that looks like this: int [ ';' int] and returns a list of the
+	// integers
+	private static List<Integer> parseSemicolonSeparatedIntList(String text) {
+		final List<Integer> result = new ArrayList<>(10);
+		int crtValue = 0;
+		for (int i = 0; i < text.length(); i++) {
+			char ch = text.charAt(i);
+			if (ch >= '0' && ch <= '9') {
+				crtValue *= 10;
+				crtValue += ch - '0';
+			} else {
+				result.add(crtValue);
+				crtValue = 0;
+			}
+		}
+		result.add(crtValue);
+		return result;
+	}
+
+	private void interpretCommand(List<Integer> nCommands) {
+
+		Iterator<Integer> iter = nCommands.iterator();
+		while (iter.hasNext()) {
+			int nCmd = iter.next();
+			switch (nCmd) {
+			case COMMAND_ATTR_RESET:
+				reset();
+				break;
+
+			case COMMAND_ATTR_INTENSITY_BRIGHT:
+				bold = true;
+				break;
+			case COMMAND_ATTR_INTENSITY_FAINT: // Intentional fallthrough
+			case COMMAND_ATTR_INTENSITY_NORMAL:
+				bold = false;
+				break;
+
+			case COMMAND_ATTR_ITALIC:
+				italic = true;
+				break;
+			case COMMAND_ATTR_ITALIC_OFF:
+				italic = false;
+				break;
+
+			case COMMAND_ATTR_UNDERLINE:
+				underline = SWT.UNDERLINE_SINGLE;
+				break;
+			case COMMAND_ATTR_UNDERLINE_DOUBLE:
+				underline = SWT.UNDERLINE_DOUBLE;
+				break;
+			case COMMAND_ATTR_UNDERLINE_OFF:
+				underline = AnsiConsoleAttributes.UNDERLINE_NONE;
+				break;
+
+			case COMMAND_ATTR_CROSSOUT_ON:
+				strike = true;
+				break;
+			case COMMAND_ATTR_CROSSOUT_OFF:
+				strike = false;
+				break;
+
+			case COMMAND_ATTR_NEGATIVE_ON:
+				invert = true;
+				break;
+			case COMMAND_ATTR_NEGATIVE_OFF:
+				invert = false;
+				break;
+
+			case COMMAND_ATTR_CONCEAL_ON:
+				conceal = true;
+				break;
+			case COMMAND_ATTR_CONCEAL_OFF:
+				conceal = false;
+				break;
+
+			case COMMAND_ATTR_FRAMED_ON:
+				framed = true;
+				break;
+			case COMMAND_ATTR_FRAMED_OFF:
+				framed = false;
+				break;
+
+			case COMMAND_COLOR_FOREGROUND_RESET:
+				currentFgColor = null;
+				break;
+			case COMMAND_COLOR_BACKGROUND_RESET:
+				currentBgColor = null;
+				break;
+
+			case COMMAND_HICOLOR_FOREGROUND:
+			case COMMAND_HICOLOR_BACKGROUND: // {esc}[48;5;{color}m
+				int color = -1;
+				int nMustBe2or5 = iter.hasNext() ? iter.next() : -1;
+				if (nMustBe2or5 == 5) { // 256 colors
+					color = iter.hasNext() ? iter.next() : -1;
+					if (!AnsiConsoleColorPalette.isValidIndex(color))
+						color = -1;
+				} else if (nMustBe2or5 == 2) { // rgb colors
+					int r = iter.hasNext() ? iter.next() : -1;
+					int g = iter.hasNext() ? iter.next() : -1;
+					int b = iter.hasNext() ? iter.next() : -1;
+					color = AnsiConsoleColorPalette.hackRgb(r, g, b);
+				}
+				if (color != -1) {
+					if (nCmd == COMMAND_HICOLOR_FOREGROUND)
+						currentFgColor = color;
+					else
+						currentBgColor = color;
+				}
+				break;
+
+			case -1:
+				break; // do nothing
+
+			default:
+				if (nCmd >= COMMAND_COLOR_FOREGROUND_FIRST && nCmd <= COMMAND_COLOR_FOREGROUND_LAST) // text color
+					currentFgColor = nCmd - COMMAND_COLOR_FOREGROUND_FIRST;
+				else if (nCmd >= COMMAND_COLOR_BACKGROUND_FIRST && nCmd <= COMMAND_COLOR_BACKGROUND_LAST) // background
+																											// color
+					currentBgColor = nCmd - COMMAND_COLOR_BACKGROUND_FIRST;
+				else if (nCmd >= COMMAND_HICOLOR_FOREGROUND_FIRST && nCmd <= COMMAND_HICOLOR_FOREGROUND_LAST) // text
+																												// color
+					currentFgColor = nCmd - COMMAND_HICOLOR_FOREGROUND_FIRST + COMMAND_COLOR_INTENSITY_DELTA;
+				else if (nCmd >= COMMAND_HICOLOR_BACKGROUND_FIRST && nCmd <= COMMAND_HICOLOR_BACKGROUND_LAST) // background
+																												// color
+					currentBgColor = nCmd - COMMAND_HICOLOR_BACKGROUND_FIRST + COMMAND_COLOR_INTENSITY_DELTA;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Refactor code: split LineStyleListener and PositionUpdater in 2
separates classes.

The AnsiConsolePositionUpdater constructs the positions for the escape
codes AND colorized text area. The built AnsiPosition contains the
associated StyleRange.

On the other side, the AnsiConsoleStyleListener initialize the
PositionUpdater when a new document is processed and update the
LyneStyleEvent styles accordingly to the overlapping AnsiPosition.

There was a static AnsiConsoleAttributes variable named current in the
AnsiPosition class that provides random color error when many builds are
run in parallel. This variable does not exist anymore after this
refactoring.

The AnsiConsolePreferenceUtils.tryPreservingStdErrColor() is not
supported by this implementation. I dont't understand the use case.

The offsetToStyleRangeCache does not exist anymore. I haven't seen any
latency in the console with big outputs.

