### PR TITLE
Make org.eclipse.m2e.launching dependency optional

### DIFF
--- a/AnsiConsole/META-INF/MANIFEST.MF
+++ b/AnsiConsole/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.console,
  org.eclipse.jface.text,
- org.eclipse.m2e.launching,
+ org.eclipse.m2e.launching;resolution:=optional,
  org.eclipse.debug.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
The commit https://github.com/mihnita/ansi-econsole/commit/ec6b9e66af2e7a84fa321d46fade0e11e328b989 introduces a required dependency to `org.eclipse.m2e.launching` which prevents using the current release in Eclipse installations where m2e is not present.

This PR makes that dependency optional.